### PR TITLE
fix(build): pin meta-package versions

### DIFF
--- a/DevSlop/DevSlop.csproj
+++ b/DevSlop/DevSlop.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />


### PR DESCRIPTION
Temporary work-around to pin the versions of a meta-package so that discovery of deps works as expected. This is not a recommended solution but a temp fix for Snyk's build.